### PR TITLE
Release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"svelte": "src/index.js",
 	"module": "dist/index.mjs",
 	"main": "dist/index.js",
+	"types": "types/index.d.ts",
 	"license": "MIT",
 	"scripts": {
 		"build": "rollup -c",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,12 @@
+import {SvelteComponentTyped} from "svelte";
+// import {} from "ag-grid-community"
+
+interface AgGridProps {
+    columnDefs: any;
+    data: any;
+    theme?: string;
+    options?: any;
+    loading?: boolean;
+}
+
+export class AgGrid extends SvelteComponentTyped<AgGridProps>{};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,21 @@
-import {SvelteComponentTyped} from "svelte";
-// import {} from "ag-grid-community"
+import { SvelteComponent } from "svelte";
 
-interface AgGridProps {
-    columnDefs: any;
-    data: any;
-    theme?: string;
-    options?: any;
-    loading?: boolean;
-}
+/* TODO: Use when updated to Svelte ^3.31.0 with SvelteComponentTyped */
+/**
+ * import { ColDef, GridOptions } from "ag-grid-community"
+ *
+ * interface AgGridProps {
+ *  columnDefs: ColDef;
+ *  data: any;
+ *  theme?: string;
+ *  options?: GridOptions;
+ *  loading?: boolean;
+ * }
+ *
+ * declare class AgGridComponent extends SvelteComponentTyped<AgGridProps> {}
+*/
 
-export class AgGrid extends SvelteComponentTyped<AgGridProps>{};
+declare class AgGridComponent extends SvelteComponent { }
+
+export default AgGridComponent;
+


### PR DESCRIPTION
## Updated:
- Use Svelte `^3.31.0` to have access to `SvelteComponentTyped`
- Use rollup-plugin-svelte `7.1.0` for compatibility with svelte `v3.31.0`
- Typed exports from index.js

## Version
Increased to `v1.1.0` due to possible conflicts with Svelte `v3.31.0`